### PR TITLE
Tv show: add check upon season and episode

### DIFF
--- a/resources/lib/OSUtilities.py
+++ b/resources/lib/OSUtilities.py
@@ -36,7 +36,7 @@ class OSDBServer:
         else:
           return None
 
-      if len(item['tvshow']) > 0:
+      if len(item['tvshow']) > 0 and len(item['season']) > 0 and len(item['episode']) > 0:
         OS_search_string = ("%s S%.2dE%.2d" % (item['tvshow'],
                                                 int(item['season']),
                                                 int(item['episode']),)


### PR DESCRIPTION
When using some plugins that does not populate the search item, the user gets an error telling him that he did not provide the authentication informations even if he did. By adding some checks on the search item in case of TV show, we prevent user from getting the authentication error when it is something else.

By adding some logs **without** this fix, I got this:
```
12:23:24 T:140086373074688   DEBUG: CPythonInvoker(5, /home/user/.kodi/addons/service.subtitles.opensubtitles/service.py): instantiating addon using automatically obtained id of "service.subtitles.opensubtitles" dependent on version 2.1.0 of the xbmc.python api
12:23:24 T:140087947815360   DEBUG: ------ Window Deinit (VideoOSD.xml) ------
12:23:25 T:140086373074688   DEBUG: ### [__main__] - action 'search' called
12:23:25 T:140086373074688   DEBUG: ### [__main__] - VideoPlayer.OriginalTitle not found
12:23:25 T:140086373074688   DEBUG: ### [__main__] - Searching for {'mansearch': False, 'episode': '', 'temp': True, 'title': 'La Rolls des barbecues', 'season': '', 'tvshow': '=\x00\x00\x00\x00\x00\x00\x0012\x00', 'rar': False, 'year': '', 'file_original_path': u'https://vd42.mycdn.me/?expires=1484133216576&srcIp=78.232.65.26&srcAg=IE_11&type=2&sig=2fa0fc702cfed0a509bb86f0799e65a6685aa092&ct=0&urls=217.20.157.196%3B5.61.22.70%3B5.61.21.103&clientType=0&id=45634619954', '3let_language': ['eng']}
12:23:25 T:140086373074688  NOTICE: send:
[...]
12:23:25 T:140086373074688   DEBUG: ### [__main__] - failed to connect to service for subtitle search: invalid literal for int() with base 10: '':
                                              File "/home/user/.kodi/addons/service.subtitles.opensubtitles/service.py", line 43, in Search
                                                search_data = OSDBServer().searchsubtitles(item)
                                              File "/home/user/.kodi/addons/service.subtitles.opensubtitles/resources/lib/OSUtilities.py", line 43, in searchsubtitles
                                                int(item['season']),
12:23:25 T:140086373074688   DEBUG: LocalizeStrings: no translation available in currently set gui language, at path /home/user/.kodi/addons/service.subtitles.opensubtitles/resources/language/French
12:23:25 T:140086373074688   DEBUG: POParser: loaded 5 strings from file /home/user/.kodi/addons/service.subtitles.opensubtitles/resources/language/English/strings.po
```

