### PR TITLE
Update service.py

### DIFF
--- a/service.py
+++ b/service.py
@@ -47,7 +47,7 @@ def Search( item ):
 				     not x['LanguageName'] == PreferredSub])
     for item_data in search_data:
       ## hack to work around issue where Brazilian is not found as language in XBMC
-      if item_data["LanguageName"] == "Brazilian":
+      if item_data["LanguageName"] == "Portuguese (BR)":
         item_data["LanguageName"] = "Portuguese (Brazil)"
 
       if ((item['season'] == item_data['SeriesSeason'] and


### PR DESCRIPTION
Fix downloading Portuguese Brazilian subtitles to match the new naming convention of open subtitles. Without this, Portuguese Brazilian subtitles filename don't have a language code.